### PR TITLE
Fix missing repo path defaults in tests

### DIFF
--- a/tests/utils/base_test_case.py
+++ b/tests/utils/base_test_case.py
@@ -17,6 +17,13 @@ class BaseTestCase(unittest.TestCase):
         if self.test_environment:
             self.test_folder = os.environ.get('CONTAINER_TEST_FOLDER')
             self.repo_folder = os.environ.get('CONTAINER_REPO_FOLDER')
+
+        # Default to the current repository when running tests locally
+        if not self.repo_folder:
+            self.repo_folder = os.getcwd()
+        if not self.test_folder:
+            self.test_folder = os.path.join(self.repo_folder, 'tests')
+
         self.addons_folder = os.path.join(self.repo_folder, 'release')
 
         sys.path.append(self.repo_folder)


### PR DESCRIPTION
## Summary
- default to repository root when test environment variables are missing

## Testing
- `pytest` *(fails: ConnectionRefusedError: No connection could be made because the target machine actively refused it)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8a2a72808332af7c145810361f8a